### PR TITLE
Move ext-pcntl to composer suggest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
 	],
 	"require": {
 		"php": ">=5.3.0",
-		"ext-pcntl": "*",
 		"monolog/monolog": ">=1.2.0",
 		"kamisama/monolog-init": ">=0.1.1"
 	},
@@ -28,7 +27,8 @@
 		}
 	},
 	"suggest": {
-		"fresque/fresque": "A command line tool to manage your workers"
+		"fresque/fresque": "A command line tool to manage your workers",   
+		"ext-pcntl": "*"
 	},
 	"support": {
 		"email": "kami@kamisama.me",


### PR DESCRIPTION
Having it in "require" section prevents installing all versions after 1.2.3 on Windows (because pcntl extension is not available for Windows).
