### PR TITLE
Performing a DB select when the DB is set to default '0' is not necessary and breaks Twemproxy

### DIFF
--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -98,7 +98,9 @@ class Resque
 			self::$redis = $redisInstance;
 		}
 
-		if(self::$redisDatabase !== 0) self::$redis->select(self::$redisDatabase);
+		if(self::$redisDatabase !== 0) {
+			self::$redis->select(self::$redisDatabase);
+		} 
 		
 		return self::$redis;
 	}


### PR DESCRIPTION
By default, the database is 0, so there is no need to select a database if '0' is provided. (http://download.redis.io/redis-stable/redis.conf)

This also makes php-resque-ex compliant with twemproxy, which does not support the 'select' command.
