### PR TITLE
Fix for an error with CakeResque

### DIFF
--- a/lib/Redisent/Redisent.php
+++ b/lib/Redisent/Redisent.php
@@ -145,6 +145,14 @@ class Redisent {
     }
 
     private function formatArgument($arg) {
+        if (is_array($arg)) {
+            $len = 0;
+            foreach ($arg as $a) {
+                $len += strlen($a);
+            }
+        } else {
+            $len = strlen($arg);
+        }
         return sprintf('$%d%s%s', strlen($arg), CRLF, $arg);
     }
 }


### PR DESCRIPTION
- An array is passed to formatArgument() within Redisent.php, where an error is generated each time strlen() is run on the array
- Also mentioned in kamisama/Cake-Resque#30 by krazp
- This change simply checks whether the parameter is an array, if yes, it adds up the lengths of each value in the array
- If it doesn't get an array, it simply checks the length expecting a string
