### PR TITLE
Add bin/resque to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
 		"issues": "https://github.com/kamisama/php-resque-ex/issues",
 		"source": "https://github.com/kamisama/php-resque-ex"
 	},
+	"bin": [
+		"bin/resque"
+	],
 	"conflict": {
 		"chrisboulton/php-resque": "*"
 	}


### PR DESCRIPTION
Simple pull request so that Composer will symlink the resque binary into the global `vendor/bin` location. As seen in the [original](https://github.com/chrisboulton/php-resque/blob/master/composer.json#L33-L35).
