### PR TITLE
Catch redis connection issue

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -205,7 +205,7 @@ class Resque_Worker
                     $job = $this->reserve();
                 }
                 catch (\RedisException $e) {
-                    $this->log(array('message' => $job . ' failed: ' . $e->getMessage(), 'data' => array('type' => 'fail', 'log' => $e->getMessage(), 'job_id' => null, 'time' => time())), self::LOG_TYPE_ERROR);
+                    $this->log(array('message' => 'Redis exception caught: ' . $e->getMessage(), 'data' => array('type' => 'fail', 'log' => $e->getMessage(), 'time' => time())), self::LOG_TYPE_ALERT);
                 }
             }
 


### PR DESCRIPTION
Catches `RedisExceptions` and logs them without killing resque.
