### PR TITLE
Fixed missing password attribute breaking constructor

### DIFF
--- a/lib/Resque.php
+++ b/lib/Resque.php
@@ -35,6 +35,11 @@ class Resque
 	protected static $namespace = '';
 
 	/**
+	 * @var string password for the redis server
+	 */
+	protected static $password = null;
+
+	/**
 	 * @var int PID of current process. Used to detect changes when forking
 	 *  and implement "thread" safety to avoid race conditions.
 	 */


### PR DESCRIPTION
Your latest commit left off the password attribute for the Redis class, breaking the build!
