### PR TITLE
Fixed ps Command so that it is compatible with Solaris systems

### DIFF
--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -509,7 +509,7 @@ class Resque_Worker
     public function workerPids()
     {
         $pids = array();
-        exec('ps -A -o pid,command | grep [r]esque', $cmdOutput);
+        exec('ps -A -o pid,comm | grep [r]esque', $cmdOutput);
         foreach ($cmdOutput as $line) {
             list($pids[]) = explode(' ', trim($line), 2);
         }


### PR DESCRIPTION
On solaris-based systems such as smartos , which is being used by PagodaBox hosting platform, the ps command as it is doesn't work. I have fixed it so that it works on solaris and Linux at the same time. 