### PR TITLE
Update Redisent.php

### DIFF
--- a/lib/Redisent/Redisent.php
+++ b/lib/Redisent/Redisent.php
@@ -70,7 +70,9 @@ class Redisent {
 
         /* Build the Redis unified protocol command */
         array_unshift($args, strtoupper($name));
-        $command = sprintf('*%d%s%s%s', count($args), CRLF, implode(array_map(array($this, 'formatArgument'), $args), CRLF), CRLF);
+
+	/* old syntax was not working on php 8.1 it's provide impload syntax error */
+        $command = sprintf('*%d%s%s%s', count($args), CRLF, implode(CRLF, array_map(array($this, 'formatArgument'), $args)), CRLF);
 
         /* Open a Redis connection and execute the command */
         for ($written = 0; $written < strlen($command); $written += $fwrite) {


### PR DESCRIPTION
old syntax was not working on PHP 8.1 it's providing an Impload syntax error. it should be the first param as Separator and the second param as Array.